### PR TITLE
feature: add currency option

### DIFF
--- a/Mission.VR/VASS/CfgFunctions.hpp
+++ b/Mission.VR/VASS/CfgFunctions.hpp
@@ -11,5 +11,7 @@ class TER
 		class addShopCargo {};
 		class addShop {};
 		class resetTimer {};
+		class getCurrency {};
+		class setCurrency {};
 	};
 };

--- a/Mission.VR/VASS/fnc/fn_getCurrency.sqf
+++ b/Mission.VR/VASS/fnc/fn_getCurrency.sqf
@@ -1,0 +1,19 @@
+/*
+	Author: M1keSK
+
+	Description:
+		Get currency of shop.
+
+	Parameter(s):
+		0:	OBJECT - Shop object
+
+	Returns:
+		STRING - return currency symbol for shop
+
+	Example(s):
+		[cursorObject] call TER_fnc_getCurrency; //-> $
+*/
+params ["_object"];
+private _currency = _object getVariable ["TER_VASS_currency", missionNamespace getVariable ["TER_VASS_currency", "$"]];
+
+_currency

--- a/Mission.VR/VASS/fnc/fn_setCurrency.sqf
+++ b/Mission.VR/VASS/fnc/fn_setCurrency.sqf
@@ -1,0 +1,20 @@
+/*
+	Author: M1keSK
+
+	Description:
+		Set currency of shop.
+
+	Parameter(s):
+		0:	OBJECT - Shop object
+		1:	STRING - currency symbol
+
+	Returns:
+		nothing
+
+	Example(s):
+		[cursorObject, "€"] call TER_fnc_setCurrency;
+		[cursorObject, "£"] call TER_fnc_setCurrency;
+		[cursorObject, "Ұ"] call TER_fnc_setCurrency;
+*/
+params ["_object", ["_currency", missionNamespace getVariable ["TER_VASS_currency", "$"]]];
+_object setVariable ["TER_VASS_currency", _currency];

--- a/Mission.VR/VASS/fnc/fn_shop.sqf
+++ b/Mission.VR/VASS/fnc/fn_shop.sqf
@@ -319,7 +319,7 @@ switch _mode do {
 					_ctrlList lnbSetValue [[_row, COL_COUNT], 0];
 					_ctrlList lnbSetValue [[_row, COL_STARTCOUNT], _startAmount];*/
 					//_ctrlList lnbSetText [[_row, COL_COUNT], format ["%1/%2", _startAmount, _startAmount + _itemMax]];
-					_ctrlList lnbSetText [[_row, _newColumn], format ["%1$", [_itemCost] call BIS_fnc_numberText]];
+					_ctrlList lnbSetText [[_row, _newColumn], format ["%1%2", [_itemCost] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency]];
 					_ctrlList lnbSetColor [[_row,_newColumn], MONEYGREEN];
 				};
 			} else {
@@ -335,7 +335,7 @@ switch _mode do {
 						private _curText = _ctrlList lbText _row;
 						private _text = [format ["%2", _itemAmount, _curText], _curText] select (_itemAmount isEqualTo true);// TODO: Find way to display item amount
 						_ctrlList lbSettext [_row, _text];
-						_ctrlList lbSetTextRight [_row,format ["%1$", [_itemCost] call BIS_fnc_numberText]];
+						_ctrlList lbSetTextRight [_row,format ["%1%2", [_itemCost] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency]];
 						_ctrlList lbSetColorRight [_row, MONEYGREEN];
 						_ctrlList lbsetvalue [_row, _itemCost];
 					} else {
@@ -1060,7 +1060,7 @@ switch _mode do {
 								private _displayName = gettext (_cfgMag >> "displayName");
 								([TER_VASS_shopObject, _mag] call TER_fnc_getItemValues) params ["","_itemCost","_itemMax"];
 								private _text = if (_itemMax isEqualType true) then {str _value} else { format ["%1|%2", _value, _itemMax - ([_mag] call _fncCurAdd)] };
-								private _lbAdd = _ctrlList lnbaddrow ["", _displayName, _text, format ["%1$", [_itemCost] call BIS_fnc_numberText]];
+								private _lbAdd = _ctrlList lnbaddrow ["", _displayName, _text, format ["%1%2", [_itemCost] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency]];
 								_ctrlList lnbSetColor [[_lbAdd,3],MONEYGREEN];
 								_ctrlList lnbsetdata [[_lbAdd,0],_mag];
 								_ctrlList lnbsetvalue [[_lbAdd,0],getnumber (_cfgMag >> "mass")];
@@ -1085,7 +1085,7 @@ switch _mode do {
 										private _displayName = gettext (_cfgMag >> "displayName");
 										([TER_VASS_shopObject, _mag] call TER_fnc_getItemValues) params ["","_itemCost","_itemMax"];
 										private _text = if (_itemMax isEqualType true) then {str _value} else { format ["%1|%2", _value, _itemMax - ([_mag] call _fncCurAdd)] };
-										private _lbAdd = _ctrlList lnbaddrow ["", _displayName, _text, format ["%1$", [_itemCost] call BIS_fnc_numberText]];
+										private _lbAdd = _ctrlList lnbaddrow ["", _displayName, _text, format ["%1%2", [_itemCost] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency]];
 										_ctrlList lnbSetColor [[_lbAdd,3],MONEYGREEN];
 										_ctrlList lnbsetdata [[_lbAdd,0],_mag];
 										_ctrlList lnbsetvalue [[_lbAdd,0],getnumber (_cfgMag >> "mass")];
@@ -1175,7 +1175,7 @@ switch _mode do {
 					if (_ctrlList lbPictureRight _lbAdd == "") then {
 						_ctrlList lbSetPictureRight [_lbAdd,"\a3\ui_f\data\igui\cfg\targeting\empty_ca.paa"];
 					};
-					_ctrlList lbSetTextRight [_lbAdd,format ["%1$", [_itemCost] call BIS_fnc_numberText]];
+					_ctrlList lbSetTextRight [_lbAdd,format ["%1%2", [_itemCost] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency]];
 					_ctrlList lbSetColorRight [_lbAdd, MONEYGREEN];
 					// MODDED*/
 				};
@@ -1480,7 +1480,7 @@ switch _mode do {
 			private _tColor = [_tGreen, _tRed] select _tCond;
 			private _tSign = ["+","-"] select _tCond;
 			if (_money == 0) then {_tColor = _tWhite; _tSign = "";};
-			private _tReturn = format ["<t align='%1' color='%2'>%3%4$</t>", _align, _tColor, _tSign, _tMoney];
+			private _tReturn = format ["<t align='%1' color='%2'>%3%4%5</t>", _align, _tColor, _tSign, _tMoney, [TER_VASS_shopObject] call TER_fnc_getCurrency];
 			_tReturn
 		};
 		//--- Funds

--- a/Mission.VR/VASS/gui/scripts/RscDisplayCheckout.sqf
+++ b/Mission.VR/VASS/gui/scripts/RscDisplayCheckout.sqf
@@ -65,8 +65,8 @@ switch _mode do {
 				"",
 				format ["%1x", abs _amount],
 				_itemName,
-				format ["%1$",[_itemPrice] call BIS_fnc_numberText],
-				format ["%1$",[_itemPrice * abs _amount] call BIS_fnc_numberText]
+				format ["%1%2",[_itemPrice] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency],
+				format ["%1%2",[_itemPrice * abs _amount] call BIS_fnc_numberText, [TER_VASS_shopObject] call TER_fnc_getCurrency]
 			];
 			_ctrl lbsettooltip [_ind * _columns, _itemName];
 			_ctrl lnbSetPicture [[_ind,0],_itemPicture];
@@ -90,7 +90,7 @@ switch _mode do {
 			_tSign = "";
 			if (_money == 0) then {_tColor = _tWhite; _tSign = "";};
 			//if (_money > 0) then {_tSign = "+"};
-			format ["<t align='%1' color='%2'>%3%4$</t>", _align, _tColor, _tSign, _tMoney]
+			format ["<t align='%1' color='%2'>%3%4%5</t>", _align, _tColor, _tSign, _tMoney, [TER_VASS_shopObject] call TER_fnc_getCurrency]
 		};
 		//--- Funds
 		_funds = with missionnamespace do {["getMoney",[_center]] call TER_fnc_VASShandler};

--- a/README.md
+++ b/README.md
@@ -176,9 +176,6 @@ This are the currently available functions which can be used to influence the sy
 ### TER_fnc_getCurrency
 ```
 /*
-	Author: Terra
-
-	/*
 	Author: M1keSK
 
 	Description:

--- a/README.md
+++ b/README.md
@@ -173,6 +173,48 @@ This are the currently available functions which can be used to influence the sy
 		["setMoney", [player, -5900]] call TER_fnc_VASShandler; //-> nil
 */
 ```
+### TER_fnc_getCurrency
+```
+/*
+	Author: Terra
+
+	/*
+	Author: M1keSK
+
+	Description:
+		Get currency of shop.
+
+	Parameter(s):
+		0:	OBJECT - Shop object
+
+	Returns:
+		STRING - return currency symbol for shop
+
+	Example(s):
+		[cursorObject] call TER_fnc_getCurrency; //-> $
+*/
+```
+### TER_fnc_setCurrency
+```
+/*
+	Author: M1keSK
+
+	Description:
+		Set currency of shop.
+
+	Parameter(s):
+		0:	OBJECT - Shop object
+		1:	STRING - currency symbol
+
+	Returns:
+		nothing
+
+	Example(s):
+		[cursorObject, "€"] call TER_fnc_setCurrency;
+		[cursorObject, "£"] call TER_fnc_setCurrency;
+		[cursorObject, "Ұ"] call TER_fnc_setCurrency;
+*/
+```
 
 ## Screenshots
 ### Ingame


### PR DESCRIPTION
Adding currency option to shop.

- respecting naming conventions
- using variable `TER_VASS_currency`
- adding default currency option as `$`
- adding possibility to change currency for separate shops or globally for all of them via variable